### PR TITLE
Fix: Kapt Compiler

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.android)
     id("kotlin-parcelize")
     id("com.google.devtools.ksp") // ksp
-    id("kotlin-kapt") // kapt
 }
 
 android {


### PR DESCRIPTION
Removed the compiler in totality. 
Wasn't needed with KSP plugin.